### PR TITLE
Use WebAppInfo for Luvo web app button

### DIFF
--- a/services/telegram_bot.py
+++ b/services/telegram_bot.py
@@ -1,6 +1,6 @@
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import CommandStart
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 
 from core.config import settings
 
@@ -10,7 +10,13 @@ bot = Bot(token=settings.TELEGRAM_BOT_TOKEN)
 dp = Dispatcher()
 
 main_keyboard = InlineKeyboardMarkup(
-    inline_keyboard=[[InlineKeyboardButton(text="Открыть Luvo", url=APP_LINK)]]
+    inline_keyboard=[
+        [
+            InlineKeyboardButton(
+                text="Открыть Luvo", web_app=WebAppInfo(url=APP_LINK)
+            )
+        ]
+    ]
 )
 
 


### PR DESCRIPTION
## Summary
- import `WebAppInfo` and use it to open Luvo web app from Telegram bot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b19f43dc788327b499299ae702a931