### PR TITLE
Toggle like/unlike in interactions endpoint

### DIFF
--- a/schemas/like.py
+++ b/schemas/like.py
@@ -4,6 +4,7 @@ from schemas.user import UserRead
 
 
 class LikeResponse(BaseModel):
+    liked: bool
     matched: bool
     match_user: Optional[UserRead] = None
 


### PR DESCRIPTION
## Summary
- add `liked` flag to like response
- turn `/interactions/like/{user_id}` into toggle that removes existing likes and matches

## Testing
- `pytest`
- `python -m py_compile routers/interactions.py schemas/like.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a6c1df44832782e9c7ef661cb1c0