### PR TITLE
Добавлены эндпоинты битвы привлекательности

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from routers.user import router as user_router
 from routers.feed import router as feed_router
 from routers.interactions import router as interactions_router
 from routers.photos import router as photo_router
+from routers.battle import router as battle_router
 
 from utils.seed_db import seed
 from services.telegram_bot import start_bot, bot
@@ -36,6 +37,7 @@ app.include_router(user_router)
 app.include_router(feed_router)
 app.include_router(interactions_router)
 app.include_router(photo_router)
+app.include_router(battle_router)
 
 
 @app.on_event("startup")

--- a/models/battle_result.py
+++ b/models/battle_result.py
@@ -1,0 +1,17 @@
+# models/battle_result.py
+from sqlalchemy import Column, BigInteger, ForeignKey, DateTime
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class BattleResult(Base):
+    __tablename__ = "battle_results"
+
+    id = Column(BigInteger, primary_key=True, index=True)
+    winner_id = Column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    loser_id = Column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<BattleResult winner={self.winner_id} loser={self.loser_id}>"

--- a/models/user.py
+++ b/models/user.py
@@ -23,6 +23,11 @@ class User(Base):
     latitude = Column(Float, nullable=True)
     longitude = Column(Float, nullable=True)
 
+    # Показатели "Битвы привлекательности"
+    battle_wins = Column(Integer, default=0, nullable=False)
+    battle_losses = Column(Integer, default=0, nullable=False)
+    battle_rating = Column(Integer, default=0, nullable=False)
+
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     def __repr__(self):

--- a/routers/battle.py
+++ b/routers/battle.py
@@ -1,0 +1,151 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import get_db
+from core.security import get_current_user
+from models.user import User
+from models.battle_result import BattleResult
+from schemas.user import UserRead
+from schemas.battle import (
+    BattlePairResponse,
+    BattleVoteRequest,
+    BattleVoteResponse,
+    BattleRatingResponse,
+    BattleLeaderboardItem,
+)
+from utils.s3 import build_photo_urls
+
+router = APIRouter(prefix="/battle", tags=["battle"])
+
+
+async def _user_to_read(user: User, db: AsyncSession) -> UserRead:
+    photos = await build_photo_urls(user.id, db)
+    return UserRead(
+        user_id=user.id,
+        telegram_user_id=user.telegram_user_id,
+        first_name=user.first_name,
+        birthdate=user.birthdate,
+        gender=user.gender,
+        about=user.about,
+        latitude=user.latitude,
+        longitude=user.longitude,
+        telegram_username=user.telegram_username,
+        instagram_username=user.instagram_username,
+        is_premium=user.is_premium,
+        premium_expires_at=user.premium_expires_at,
+        created_at=user.created_at,
+        photos=photos,
+    )
+
+
+@router.get("/pair", response_model=BattlePairResponse)
+async def get_pair(
+    winner_id: int | None = Query(None, description="ID победителя, если он остаётся"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BattlePairResponse:
+    if winner_id:
+        winner = await db.get(User, winner_id)
+        if not winner:
+            raise HTTPException(status_code=404, detail="Winner not found")
+        stmt = (
+            select(User)
+            .where(User.id.notin_([current_user.id, winner_id]))
+            .order_by(func.random())
+            .limit(1)
+        )
+        res = await db.execute(stmt)
+        opponent = res.scalar_one_or_none()
+        if not opponent:
+            raise HTTPException(status_code=404, detail="No opponent found")
+        return BattlePairResponse(
+            left=await _user_to_read(winner, db),
+            right=await _user_to_read(opponent, db),
+        )
+    else:
+        stmt = (
+            select(User)
+            .where(User.id != current_user.id)
+            .order_by(func.random())
+            .limit(2)
+        )
+        res = await db.execute(stmt)
+        users = res.scalars().all()
+        if len(users) < 2:
+            raise HTTPException(status_code=404, detail="Not enough users")
+        return BattlePairResponse(
+            left=await _user_to_read(users[0], db),
+            right=await _user_to_read(users[1], db),
+        )
+
+
+@router.post("/vote", response_model=BattleVoteResponse)
+async def vote(
+    payload: BattleVoteRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BattleVoteResponse:
+    winner = await db.get(User, payload.winner_id)
+    loser = await db.get(User, payload.loser_id)
+    if not winner or not loser:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    db.add(BattleResult(winner_id=winner.id, loser_id=loser.id))
+    winner.battle_wins += 1
+    winner.battle_rating += 1
+    loser.battle_losses += 1
+    await db.commit()
+
+    stmt = (
+        select(User)
+        .where(User.id.notin_([current_user.id, winner.id, loser.id]))
+        .order_by(func.random())
+        .limit(1)
+    )
+    res = await db.execute(stmt)
+    opponent = res.scalar_one_or_none()
+    if not opponent:
+        raise HTTPException(status_code=404, detail="No opponent found")
+
+    return BattleVoteResponse(
+        winner=await _user_to_read(winner, db),
+        opponent=await _user_to_read(opponent, db),
+    )
+
+
+@router.get("/rating/{user_id}", response_model=BattleRatingResponse)
+async def get_rating(user_id: int, db: AsyncSession = Depends(get_db)) -> BattleRatingResponse:
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return BattleRatingResponse(
+        wins=user.battle_wins,
+        losses=user.battle_losses,
+        score=user.battle_rating,
+    )
+
+
+@router.get("/leaderboard", response_model=List[BattleLeaderboardItem])
+async def leaderboard(
+    limit: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> List[BattleLeaderboardItem]:
+    stmt = (
+        select(User)
+        .order_by(User.battle_rating.desc())
+        .limit(limit)
+    )
+    res = await db.execute(stmt)
+    users = res.scalars().all()
+    return [
+        BattleLeaderboardItem(
+            user_id=u.id,
+            first_name=u.first_name,
+            score=u.battle_rating,
+        )
+        for u in users
+    ]
+

--- a/schemas/battle.py
+++ b/schemas/battle.py
@@ -1,0 +1,48 @@
+# backend/schemas/battle.py
+from typing import List
+from pydantic import BaseModel, Field
+
+from schemas.user import UserRead
+
+
+class BattlePairResponse(BaseModel):
+    left: UserRead
+    right: UserRead
+
+    class Config:
+        from_attributes = True
+        validate_by_name = True
+
+
+class BattleVoteRequest(BaseModel):
+    winner_id: int = Field(..., description="ID победителя")
+    loser_id: int = Field(..., description="ID проигравшего")
+
+
+class BattleVoteResponse(BaseModel):
+    winner: UserRead
+    opponent: UserRead
+
+    class Config:
+        from_attributes = True
+        validate_by_name = True
+
+
+class BattleRatingResponse(BaseModel):
+    wins: int
+    losses: int
+    score: int
+
+    class Config:
+        from_attributes = True
+        validate_by_name = True
+
+
+class BattleLeaderboardItem(BaseModel):
+    user_id: int
+    first_name: str | None = None
+    score: int
+
+    class Config:
+        from_attributes = True
+        validate_by_name = True


### PR DESCRIPTION
## Summary
- add battle models and router for attractiveness duels
- track wins/losses/rating for users
- expose endpoints for pair selection, voting and leaderboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc9bef05a88327b73e28b53d97a550