### PR TITLE
Исправить alias user_id в UserRead

### DIFF
--- a/schemas/user.py
+++ b/schemas/user.py
@@ -47,7 +47,7 @@ class UserUpdate(BaseModel):
 
 
 class UserRead(UserBase):
-    user_id: int = Field(..., alias="user_id", description="PK в базе данных")
+    user_id: int = Field(..., alias="id", description="PK в базе данных")
 
     first_name: str = Field(..., max_length=100, description="Имя пользователя")
     birthdate: Optional[date] = Field(None, description="Дата рождения")


### PR DESCRIPTION
## Summary
- Заменён alias поля `user_id` на `id` в `UserRead`

## Testing
- `pytest`
- `uvicorn main:app --host 0.0.0.0 --port 8000` (ошибка подключения к БД)


------
https://chatgpt.com/codex/tasks/task_e_68bee807ad5883278cbc75476d59ee04